### PR TITLE
Pin libarrow to version_major.version_minor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @raulcd @xhochy @xmnlab
+* @conda-forge/arrow-cpp @raulcd @xhochy @xmnlab

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/arrow-cpp](https://github.com/orgs/conda-forge/teams/arrow-cpp/)
 * [@raulcd](https://github.com/raulcd/)
 * [@xhochy](https://github.com/xhochy/)
 * [@xmnlab](https://github.com/xmnlab/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "arrow-c-glib" %}
 {% set version = "18.1.0" %}
 {% set version_major = version.split(".")[0] %}
+{% set version_minor = version.split(".")[1] %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +12,7 @@ source:
   sha256: 2dc8da5f8796afe213ecc5e5aba85bb82d91520eff3cf315784a52d0fa61d7fc
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('arrow-c-glib', max_pin="x.x.x") }}
@@ -27,7 +28,7 @@ requirements:
     - ninja
     - pkg-config  # [osx]
   host:
-    - libarrow-all {{ version_major }}
+    - libarrow-all {{ version_major }}.{{ version_minor }}
     - glib
     - gobject-introspection
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,3 +88,4 @@ extra:
     - raulcd
     - xmnlab
     - xhochy
+    - conda-forge/arrow-cpp


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #32.

<!--
Please add any other relevant info below:
-->
I'm trying to pin things to get past the clang/protobuf/abseil issues that cropped up recently, and it seems that arrow-c-glib 18.1.0 requires libarrow 18.0.0 